### PR TITLE
Normalize line-end punctuation in OPTIONS section

### DIFF
--- a/bin/prove
+++ b/bin/prove
@@ -26,12 +26,12 @@ Boolean options:
  -v,  --verbose         Print all test lines.
  -l,  --lib             Add 'lib' to the path for your tests (-Ilib).
  -b,  --blib            Add 'blib/lib' and 'blib/arch' to the path for
-                        your tests
+                        your tests.
  -s,  --shuffle         Run the tests in random order.
  -c,  --color           Colored test output (default).
       --nocolor         Do not color test output.
       --count           Show the X/Y test count when not verbose
-                        (default)
+                        (default).
       --nocount         Disable the X/Y test count.
  -D   --dry             Dry run. Show test that would have run.
  -f,  --failures        Show failed tests.
@@ -46,34 +46,34 @@ Boolean options:
       --directives      Only show results with TODO or SKIP directives.
       --timer           Print elapsed time after each test.
       --trap            Trap Ctrl-C and print summary on interrupt.
-      --normalize       Normalize TAP output in verbose output
+      --normalize       Normalize TAP output in verbose output.
  -T                     Enable tainting checks.
  -t                     Enable tainting warnings.
  -W                     Enable fatal warnings.
  -w                     Enable warnings.
- -h,  --help            Display this help
- -?,                    Display this help
- -V,  --version         Display the version
- -H,  --man             Longer manpage for prove
-      --norc            Don't process default .proverc
+ -h,  --help            Display this help.
+ -?,                    Display this help.
+ -V,  --version         Display the version.
+ -H,  --man             Longer manpage for prove.
+      --norc            Don't process default .proverc.
 
 Options that take arguments:
 
  -I                     Library paths to include.
- -P                     Load plugin (searches App::Prove::Plugin::*.)
+ -P                     Load plugin (searches App::Prove::Plugin::*).
  -M                     Load a module.
  -e,  --exec            Interpreter to run the tests ('' for compiled
-                        tests.)
-      --ext             Set the extension for tests (default '.t')
+                        tests).
+      --ext             Set the extension for tests (default '.t').
       --harness         Define test harness to use.  See TAP::Harness.
       --formatter       Result formatter to use. See FORMATTERS.
       --source          Load and/or configure a SourceHandler. See
                         SOURCE HANDLERS.
  -a,  --archive out.tgz Store the resulting TAP in an archive file.
- -j,  --jobs N          Run N test jobs in parallel (try 9.)
+ -j,  --jobs N          Run N test jobs in parallel (try 9).
       --state=opts      Control prove's persistent state.
-      --statefile=file  Use `file` instead of `.prove` for state
-      --rc=rcfile       Process options from rcfile
+      --statefile=file  Use `file` instead of `.prove` for state.
+      --rc=rcfile       Process options from rcfile.
       --rules           Rules for parallel vs sequential processing.
 
 =head1 NOTES


### PR DESCRIPTION
This is just a suggested change to make the periods consistent. Thanks for your great work on these packages.